### PR TITLE
sliders for spacing tab

### DIFF
--- a/app.js
+++ b/app.js
@@ -35,5 +35,7 @@ Add_Custom_Style(`
 
 // listen for messages form the background script
 chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
-    console.log("received by app.js:", message);
-})
+    if (message.lineSpacingValue !== undefined) {
+        console.log("received line spacing value:", message.lineSpacingValue);
+    }  
+});

--- a/app.js
+++ b/app.js
@@ -68,4 +68,7 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
     if (message.lineSpacingValue !== undefined) {
         console.log("received line spacing value:", message.lineSpacingValue);
     }  
+    if (message.charSpacingValue !== undefined) {
+        console.log("received char spacing value:", message.charSpacingValue);
+    }
 });

--- a/app.js
+++ b/app.js
@@ -31,3 +31,9 @@ Add_Custom_Style(`
 // 2. put the user's preference into Add_Custom_Style
 // 3. need to import url for all the different language
 // 4. need to figure out how to let any website work
+
+
+// listen for messages form the background script
+chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+    console.log("received by app.js:", message);
+})

--- a/background.js
+++ b/background.js
@@ -60,3 +60,16 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         }
     }
 });
+
+
+// listen for chnages in the line spacing pref
+chrome.storage.sync.onChanged.addListener(function(changes, namespace) {
+    if (changes.prevLineSpacing) {
+        const lineSpacing = changes.prevLineSpacing.newValue;
+        // send message to app.js with the new  value
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            console.log("in background.js (line spacing):", lineSpacing);
+            chrome.tabs.sendMessage(tabs[0].id, {lineSpacingValue: lineSpacing});
+        });
+    }
+});

--- a/background.js
+++ b/background.js
@@ -92,7 +92,6 @@ chrome.storage.sync.onChanged.addListener(function(changes, namespace) {
 
 // Listen for page refresh events
 chrome.webNavigation.onCommitted.addListener(function(details) {
-    console.log(details);
     if (details.transitionType === 'reload') {
         chrome.storage.sync.get('toggleState', function(data) {
             const enable = data.toggleState;
@@ -109,16 +108,27 @@ chrome.webNavigation.onCommitted.addListener(function(details) {
 
 
 
-// listen for chnages in the line spacing pref
+
 chrome.storage.sync.onChanged.addListener(function(changes, namespace) {
+    // listen for chnages in the line spacing pref
     if (changes.prevLineSpacing) {
         console.log("line spacing changed!");
         const lineSpacing = changes.prevLineSpacing.newValue;
         // send message to app.js with the new  value
         chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
             console.log("in background.js (line spacing):", lineSpacing);
-            console.log(tabs);
             chrome.tabs.sendMessage(tabs[0].id, {lineSpacingValue: lineSpacing});
+        });
+    }
+
+    // listen for changes in the char spacing pref
+    if (changes.prevCharSpacing) {
+        console.log("char spacing changed!");
+        const charSpacing = changes.prevCharSpacing.newValue;
+        // send message to app.js with the new value
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            console.log("in background.js (char spacing):", charSpacing);
+            chrome.tabs.sendMessage(tabs[0].id, {charSpacingValue: charSpacing});
         });
     }
 });

--- a/background.js
+++ b/background.js
@@ -65,10 +65,12 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 // listen for chnages in the line spacing pref
 chrome.storage.sync.onChanged.addListener(function(changes, namespace) {
     if (changes.prevLineSpacing) {
+        console.log("line spacing changed!");
         const lineSpacing = changes.prevLineSpacing.newValue;
         // send message to app.js with the new  value
         chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
             console.log("in background.js (line spacing):", lineSpacing);
+            console.log(tabs);
             chrome.tabs.sendMessage(tabs[0].id, {lineSpacingValue: lineSpacing});
         });
     }

--- a/manifest.json
+++ b/manifest.json
@@ -24,6 +24,9 @@
     "default_popup": "login-popup.html"
   },
   "permissions": [
-    "identity"
+    "identity",
+    "storage",
+    "tabs",
+    "activeTab"
   ]
 }

--- a/preference-script.js
+++ b/preference-script.js
@@ -45,15 +45,17 @@ document.addEventListener('DOMContentLoaded', function() {
     const lineSpacingSlider = document.getElementById("line-spacing-slider");
 
     // retrieve toggle state from chrome.storage.sync
-    chrome.storage.sync.get('prevLineSpacing', function() {
+    chrome.storage.sync.get('prevLineSpacing', function(data) {
         const prevLineSpacing = data.prevLineSpacing;
         // set the line spacing based on chrome.storage.sync
-        lineSpacingSlider = prevLineSpacing;
+        if (prevLineSpacing !== undefined) {
+            lineSpacingSlider.value = prevLineSpacing;
+        }
     });
 
     // listen for change event on line spacing slider
     lineSpacingSlider.addEventListener('change', function() {
         // store the line spacing pref in chrome.storage.sync
-        chrome.storage.sync.set({ 'prevLineSpacing': lineSpacingSlider });
+        chrome.storage.sync.set({ 'prevLineSpacing': lineSpacingSlider.value });
     });
 });

--- a/preference-script.js
+++ b/preference-script.js
@@ -86,22 +86,34 @@ document.addEventListener('DOMContentLoaded', function() {
 });
 
 
-// spcing slider
-//document.addEventListener('DOMContentLoaded', function() {
-    const lineSpacingSlider = document.getElementById("line-spacing-slider");
+// spacing slider
+const lineSpacingSlider = document.getElementById("line-spacing-slider");
+const charSpacingSlider = document.getElementById("character-spacing-slider");
 
-    // retrieve toggle state from chrome.storage.sync
-    chrome.storage.sync.get('prevLineSpacing', function(data) {
-        const prevLineSpacing = data.prevLineSpacing;
-        // set the line spacing based on chrome.storage.sync
-        if (prevLineSpacing !== undefined) {
-            lineSpacingSlider.value = prevLineSpacing;
-        }
-    });
+// retrieve line spacing value from chrome.storage.sync
+chrome.storage.sync.get('prevLineSpacing', function(data) {
+    const prevLineSpacing = data.prevLineSpacing;
+    // set the line spacing based on chrome.storage.sync
+    if (prevLineSpacing !== undefined) {
+        lineSpacingSlider.value = prevLineSpacing;
+    }
+});
+// retrieve char spacing value from chrome.storage
+chrome.storage.sync.get('prevCharSpacing', function(data) {
+    const prevCharSpacing = data.prevCharSpacing;
+    // set the char spacing based on chrome.storage
+    if (prevCharSpacing !== undefined) {
+        charSpacingSlider.value = prevCharSpacing;
+    }
+});
 
-    // listen for change event on line spacing slider
-    lineSpacingSlider.addEventListener('change', function() {
-        // store the line spacing pref in chrome.storage.sync
-        chrome.storage.sync.set({ 'prevLineSpacing': lineSpacingSlider.value });
-    });
-//});
+// listen for change event on line spacing slider
+lineSpacingSlider.addEventListener('change', function() {
+    // store the line spacing pref in chrome.storage.sync
+    chrome.storage.sync.set({ 'prevLineSpacing': lineSpacingSlider.value });
+});
+// listen for change event on char spacing slider
+charSpacingSlider.addEventListener('change', function() {
+    // store the char spacing pref in chrome.storage
+    chrome.storage.sync.set({ 'prevCharSpacing': charSpacingSlider.value });
+});

--- a/preference-script.js
+++ b/preference-script.js
@@ -38,3 +38,22 @@ function openPref(prefName, tabButton) {
     tabButton.classList.add("active");
     //document.querySelector('[onclick="openPref(\'' + prefName + '\')"]').classList.add("active");
   }
+
+
+// spcing slider
+document.addEventListener('DOMContentLoaded', function() {
+    const lineSpacingSlider = document.getElementById("line-spacing-slider");
+
+    // retrieve toggle state from chrome.storage.sync
+    chrome.storage.sync.get('prevLineSpacing', function() {
+        const prevLineSpacing = data.prevLineSpacing;
+        // set the line spacing based on chrome.storage.sync
+        lineSpacingSlider = prevLineSpacing;
+    });
+
+    // listen for change event on line spacing slider
+    lineSpacingSlider.addEventListener('change', function() {
+        // store the line spacing pref in chrome.storage.sync
+        chrome.storage.sync.set({ 'prevLineSpacing': lineSpacingSlider });
+    });
+});

--- a/preference-script.js
+++ b/preference-script.js
@@ -41,7 +41,7 @@ function openPref(prefName, tabButton) {
 
 
 // spcing slider
-document.addEventListener('DOMContentLoaded', function() {
+//document.addEventListener('DOMContentLoaded', function() {
     const lineSpacingSlider = document.getElementById("line-spacing-slider");
 
     // retrieve toggle state from chrome.storage.sync
@@ -58,4 +58,4 @@ document.addEventListener('DOMContentLoaded', function() {
         // store the line spacing pref in chrome.storage.sync
         chrome.storage.sync.set({ 'prevLineSpacing': lineSpacingSlider.value });
     });
-});
+//});

--- a/preferences-popup.html
+++ b/preferences-popup.html
@@ -30,17 +30,6 @@
                 <input type="range" min="1" max="10" value="5" class="spacing-slider" id="character-spacing-slider">
             </div>
         </div>
-        <!-- line spacing slider 
-        <div>
-            <label for="line-spacing-slider">Line Spacing</label>
-        </div>
-        -->
-        <!-- character spacing slider 
-        <div>
-            <label for="character-spacing-slider">Line Spacing</label>
-            <input type="range" min="1" max="10" value="5" class="slider" id="character-spacing-slider">
-        </div> 
-        -->
         <button id="spacingSave">Save</button>
     </div>
   

--- a/preferences-popup.html
+++ b/preferences-popup.html
@@ -20,16 +20,27 @@
   
     <div id="Spacing" class="tabcontent">
         <h3>Spacing</h3>
-        <!-- line spacing slider -->
+        <div class="spacing-container">
+            <div class="spacing-group">
+                <span class="spacing-category">Line Spacing</span>
+                <input type="range" min="1" max="10" value="5" class="spacing-slider" id="line-spacing-slider">
+            </div>
+            <div class="spacing-group">
+                <span class="spacing-category">Character Spacing</span>
+                <input type="range" min="1" max="10" value="5" class="spacing-slider" id="character-spacing-slider">
+            </div>
+        </div>
+        <!-- line spacing slider 
         <div>
             <label for="line-spacing-slider">Line Spacing</label>
-            <input type="range" min="1" max="10" value="5" class="slider" id="line-spacing-slider">
         </div>
-        <!-- character spacing slider -->
+        -->
+        <!-- character spacing slider 
         <div>
             <label for="character-spacing-slider">Line Spacing</label>
             <input type="range" min="1" max="10" value="5" class="slider" id="character-spacing-slider">
-        </div>
+        </div> 
+        -->
         <button id="spacingSave">Save</button>
     </div>
   

--- a/preferences-popup.html
+++ b/preferences-popup.html
@@ -19,10 +19,15 @@
   
     <div id="Spacing" class="tabcontent">
         <h3>Spacing</h3>
-        <p>This is where spacing preference settings go.</p>
-        <div class="slider-containter">
+        <!-- line spacing slider -->
+        <div>
             <label for="line-spacing-slider">Line Spacing</label>
             <input type="range" min="1" max="10" value="5" class="slider" id="line-spacing-slider">
+        </div>
+        <!-- character spacing slider -->
+        <div>
+            <label for="character-spacing-slider">Line Spacing</label>
+            <input type="range" min="1" max="10" value="5" class="slider" id="character-spacing-slider">
         </div>
     </div>
   

--- a/preferences-popup.html
+++ b/preferences-popup.html
@@ -20,6 +20,10 @@
     <div id="Spacing" class="tabcontent">
         <h3>Spacing</h3>
         <p>This is where spacing preference settings go.</p>
+        <div class="slider-containter">
+            <label for="line-spacing-slider">Line Spacing</label>
+            <input type="range" min="1" max="10" value="5" class="slider" id="line-spacing-slider">
+        </div>
     </div>
   
     <div id="Numbers" class="tabcontent">

--- a/style.css
+++ b/style.css
@@ -135,4 +135,20 @@ input:checked + .slider:before {
     bottom: 10px;
     right: 10px;
 }
-  
+
+
+/* spacing sliders */
+.spacing-container {
+  display: flex;
+  flex-direction: column;
+  align-items: left;
+}
+
+.spacing-category {
+  font-weight: bold;
+  margin-right: 50px;
+}
+
+.spacing-group {
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
added sliders for adjusting line spacing and character spacing

stores the current selected value as `prevLineSpacing` and `prevCharSpacing` in `chrome.storage` so that it remembers the temporary setting when the popup closes

the values are currently 1-10 and are displayed in the console